### PR TITLE
Update pets_controller_spec.rb

### DIFF
--- a/spec/controllers/pets_controller_spec.rb
+++ b/spec/controllers/pets_controller_spec.rb
@@ -98,7 +98,7 @@ describe "Pets Controller" do
 
     it "edit's the pet's owner with a new owner" do
       visit "/pets/#{@pet.id}/edit"
-      fill_in "owner_name", :with => "Samantha"
+      fill_in "owner[name]", :with => "Samantha"
       click_button "Update Pet"
       expect(Pet.last.owner.name).to eq("Samantha")
     end


### PR DESCRIPTION
Changed one test in the pets controller spec to be consistent with itself and the owners controller spec. It was searching for `owner[name]` on line 81, then searching for `owner_name` on line 101. In the owner spec, it was searching for pets[name] in both. Also, this test could be passed with `<input  type="text" id="owner_name" name="owner[name]">`, but that doesn't seem as clean as having the id and name match (especially to make it consistent with the owner edit form).